### PR TITLE
Throw RuntimeException instead of System.exit()

### DIFF
--- a/src/main/java/de/unisb/cs/st/javalanche/mutation/javaagent/classFileTransfomer/MutationFileTransformer.java
+++ b/src/main/java/de/unisb/cs/st/javalanche/mutation/javaagent/classFileTransfomer/MutationFileTransformer.java
@@ -115,8 +115,7 @@ public class MutationFileTransformer implements ClassFileTransformer {
 				t.printStackTrace(new PrintWriter(writer));
 				logger.fatal(writer.getBuffer().toString());
 				t.printStackTrace();
-				System.exit(0);
-				// throw new RuntimeException(e.getMessage());
+				throw new RuntimeException(t.getMessage());
 			}
 		}
 		return classfileBuffer;


### PR DESCRIPTION
Fix #5 (at least temporarily, there might be more to this error then what I did to resolve it on my end)

Fix:
- Abrupt termination of the current runMutation task and instead throw an exception to let task continue to completion
