### PR TITLE
Easy command line properties

### DIFF
--- a/javalanche.xml
+++ b/javalanche.xml
@@ -16,7 +16,11 @@
 	<property name="project.tests" value="${tests}"/>
 	<property name="javalanche.location" value="${javalanche}" />
 	<property name="javalanche.dist.dir" value="${javalanche}" />
-	<property name="javalanche.properties" value="${javalanche.properties}" />
+
+	<!-- Allows additional properties from (de.unisb.cs.st.javalanche.mutation.properties.PropertyConfiguration) -->
+	<condition property="javalanche.config.properties" value="${javalanche.properties}" else="">
+			<isset property="javalanche.properties" />
+	</condition>
 
 	<import file="${javalanche.location}/import.xml"/>
 	<import file="${javalanche.location}/src/main/resources/javalanche-tasks.xml" />
@@ -37,7 +41,7 @@
 				<pathelement path="${cp}"></pathelement>
 			</classpath>
 
-			<jvmarg line="${javalanche.properties} ${javalanche.arg.line}" />
+			<jvmarg line="${javalanche.config.properties} ${javalanche.arg.line}" />
 
 			<formatter type="xml"/>
 			<formatter usefile="true" type="plain"/>
@@ -52,7 +56,7 @@
 			cp                    : ${cp}
 			javalanche.location   : ${javalanche.location}
 			javalanche.dist.dir   : ${javalanche.dist.dir}
-			javalanche.properties : ${javalanche.properties}
+			javalanche.config.properties : ${javalanche.config.properties}
 		</echo>
 	</target>
 

--- a/javalanche.xml
+++ b/javalanche.xml
@@ -1,9 +1,9 @@
 <project name="Javalanche">
-	
+
 <!-- Properties can either be supplied on the command line, via a properties file or specified here -->
 
 <!--
- <property file="javalanche.properties" />
+	<property file="javalanche.properties" />
 -->
 <!--
 	<property name="prefix" value=""/>
@@ -12,21 +12,20 @@
 	<property name="cp" value=""/>
 -->
 
-
 	<property name="project.prefix" value="${prefix}"/>
 	<property name="project.tests" value="${tests}"/>
 	<property name="javalanche.location" value="${javalanche}" />
 	<property name="javalanche.dist.dir" value="${javalanche}" />
-	
-		
+	<property name="javalanche.properties" value="${javalanche.properties}" />
+
 	<import file="${javalanche.location}/import.xml"/>
 	<import file="${javalanche.location}/src/main/resources/javalanche-tasks.xml" />
-    <import file="${javalanche.location}/src/main/resources/javalanche-add-tasks.xml"/>
-	
+	<import file="${javalanche.location}/src/main/resources/javalanche-add-tasks.xml"/>
+
 <!-- To compute the coverage or data impact of mutations, one this files has to be included. -->
 <!--	<import file="${javalanche.location}/src/main/resources/coverage-include.xml" /> -->
 
-	<!-- 
+	<!--
 	Task that is called by the different stages of Javalanche.
 	This task should not be called directly.
 	-->
@@ -37,27 +36,26 @@
 				<path refid="javalanche.classpath.add" />
 				<pathelement path="${cp}"></pathelement>
 			</classpath>
-			
-			<jvmarg line="${javalanche.arg.line}" />
-			
+
+			<jvmarg line="${javalanche.properties} ${javalanche.arg.line}" />
+
 			<formatter type="xml"/>
 			<formatter usefile="true" type="plain"/>
 			<test todir="${javalanche.out.dir}/junit-reports" name="${javalanche.wrapper.testsuite}" />
 		</junit>
-	</target>	
+	</target>
 
-	
 	<target name="testParameters">
 		<echo>
-			project.prefix     : ${project.prefix} 
-			project.tests 	   : ${project.tests} 
-			cp                 : ${cp} 
-			javalanche.location: ${javalanche.location}
-			javalanche.dist.dir: ${javalanche.dist.dir}
+			project.prefix        : ${project.prefix}
+			project.tests 	      : ${project.tests}
+			cp                    : ${cp}
+			javalanche.location   : ${javalanche.location}
+			javalanche.dist.dir   : ${javalanche.dist.dir}
+			javalanche.properties : ${javalanche.properties}
 		</echo>
-	</target>	
+	</target>
 
 	<target name="mutationTest" depends="startHsql,schemaexport,scanProject,scan,createSingleRandomTask,runSingleTask,analyzeResults,stopHsql"/>
-	
 
 </project>


### PR DESCRIPTION
I found it slightly cumbersome to adjust the properties of Javalanche (according to the [PropertyConfiguration.java](https://github.com/david-schuler/javalanche/blob/master/src/main/java/de/unisb/cs/st/javalanche/mutation/properties/PropertyConfiguration.java) file). I modified _javalanche.xml_ to accept these properties from the command-line (before they would not work this way). The adjustment does not influence the old functionality of Javalanche, since if no properties are provided a default value of "" is used.

The following shows how one would use this (on the triangle example) to disable all mutations except for the _replace variable_ type:

```
 ant -f javalanche.xml -Dprefix=triangle -Dcp=target/classes/:./lib/junit.jar \
 -Dtests=triangle.tests.TriangleTestSuite -Djavalanche=../../ \
 -Djavalanche.mutation.analyzers=de.unisb.cs.st.javalanche.mutation.analyze.MutationScoreAnalyzer \
 -Djavalanche.properties="-Djavalanche.enable.arithmetic.replace=false \
 -Djavalanche.enable.negate.jump=false -Djavalanche.enable.remove.call=false \
 -Djavalanche.enable.replace.constant=false -Djavalanche.enable.replace.variable=true \
 -Djavalanche.enable.absolute.value=false -Djavalanche.enable.unary.operator=false \
 -Djavalanche.enable.monitor.remove=false -Djavalanche.enable.replace.thread.call=false" mutationTest
```

---

Essentially there is a new command-line property `... -Djavalanche.properties="<properties_separated_by_spaces>" ...`
